### PR TITLE
fix a tag links to append wiki to url

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -2,10 +2,15 @@ import "./Card.css"
 import WikipediaPage from "../WikipediaPage/WikipediaPage"
 import React, {useState} from 'react';
 import DOMPurify from "dompurify";
+import modifyRelativeUrls from "../hooks/modifyRelativeUrls"
 // import star from ".../Media/star"
+
 
 const Card = ({ title, snippet }) => {
     const [showPage,setShowPage] = useState(false)
+
+  
+    const sanitizedHtml = DOMPurify.sanitize(modifyRelativeUrls(snippet));
 
     const handleTitleClick = () =>{
         setShowPage(true)
@@ -20,7 +25,7 @@ const Card = ({ title, snippet }) => {
         {/* <img src={star} alt="Star Icon" className="star-icon"/> */}
         <div className="card-content">
         <p
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(snippet) }}
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(sanitizedHtml)}}
         />
       {/* You can add more information or formatting here */}
       </div>

--- a/src/hooks/modifyRelativeUrls.js
+++ b/src/hooks/modifyRelativeUrls.js
@@ -1,0 +1,18 @@
+import DOMPurify from "dompurify";
+
+const modifyRelativeUrls = (html) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const links = doc.querySelectorAll('a[href^="/wiki/"]');
+
+
+    links.forEach((link) => {
+      const href = link.getAttribute("href");
+      link.setAttribute("href", `https://en.wikipedia.org${href}`);
+    
+    });
+    return doc.body.innerHTML; 
+  };
+
+
+  export default modifyRelativeUrls;


### PR DESCRIPTION
What I did:

⭐ Fixed the URL so that when a A tag link is clicked it goes to the Wiki article on that tag.


Did this break anything?

- [X] No
- [ ]  Yes

Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [X]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [X]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [X]  The code is DRY. If it's not, I tried my best
- [X]  I reviewed my code before pushing

What's next?

❗Removing the spans for edit tags so the user can't edit the article. 
❗Incorporating Router 